### PR TITLE
Improve use of configuration

### DIFF
--- a/experiments/asr/run.py
+++ b/experiments/asr/run.py
@@ -12,23 +12,18 @@ torch.manual_seed(123)
 batch_size = 8
 hidden_size = 1024
 dropout = 0.0
-feature_fname = 'mfcc_delta_features.pt'
 
 logging.basicConfig(level=logging.INFO)
 
 logging.info('Loading data')
 data = dict(
-    train=D.flickr8k_loader(split='train', batch_size=batch_size, shuffle=True,
-                            feature_fname=feature_fname),
-    val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False,
-                          feature_fname=feature_fname))
+    train=D.flickr8k_loader(split='train', batch_size=batch_size, shuffle=True),
+    val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False))
 fd = D.Flickr8KData
 fd.init_vocabulary(data['train'].dataset)
 
 # Saving config
-pickle.dump(dict(feature_fname=feature_fname,
-                 label_encoder=fd.get_label_encoder(),
-                 language='en'),
+pickle.dump(data['train'].dataset.get_config(),
             open('config.pkl', 'wb'))
 
 config = dict(

--- a/experiments/downsampling/asr/run.py
+++ b/experiments/downsampling/asr/run.py
@@ -14,7 +14,6 @@ torch.manual_seed(123)
 batch_size = 8
 hidden_size = 1024
 dropout = 0.0
-feature_fname = 'mfcc_delta_features.pt'
 
 logging.basicConfig(level=logging.INFO)
 
@@ -24,17 +23,14 @@ for ds_factor in factors:
     logging.info('Loading data')
     data = dict(
         train=D.flickr8k_loader(split='train', batch_size=batch_size,
-                                shuffle=True, feature_fname=feature_fname,
-                                downsampling_factor=ds_factor),
+                                shuffle=True, downsampling_factor=ds_factor),
         val=D.flickr8k_loader(split='val', batch_size=batch_size,
-                              shuffle=False, feature_fname=feature_fname))
+                              shuffle=False))
     fd = D.Flickr8KData
     fd.init_vocabulary(data['train'].dataset)
 
     # Saving config
-    pickle.dump(dict(feature_fname=feature_fname,
-                     label_encoder=fd.get_label_encoder(),
-                     language='en'),
+    pickle.dump(data['train'].dataset.get_config(),
                 open('config.pkl', 'wb'))
 
     config = dict(

--- a/experiments/downsampling/mtl-asr/run.py
+++ b/experiments/downsampling/mtl-asr/run.py
@@ -14,7 +14,6 @@ torch.manual_seed(123)
 batch_size = 8
 hidden_size = 1024
 dropout = 0.0
-feature_fname = 'mfcc_delta_features.pt'
 
 logging.basicConfig(level=logging.INFO)
 
@@ -24,17 +23,14 @@ for ds_factor in factors:
     logging.info('Loading data')
     data = dict(
         train=D.flickr8k_loader(split='train', batch_size=batch_size,
-                                shuffle=True, feature_fname=feature_fname,
-                                downsampling_factor=ds_factor),
+                                shuffle=True, downsampling_factor=ds_factor),
         val=D.flickr8k_loader(split='val', batch_size=batch_size,
-                              shuffle=False, feature_fname=feature_fname))
+                              shuffle=False))
     fd = D.Flickr8KData
     fd.init_vocabulary(data['train'].dataset)
 
     # Saving config
-    pickle.dump(dict(feature_fname=feature_fname,
-                     label_encoder=fd.get_label_encoder(),
-                     language='en'),
+    pickle.dump(data['train'].dataset.get_config(),
                 open('config.pkl', 'wb'))
 
     config = dict(

--- a/experiments/downsampling/pip-ind/run.py
+++ b/experiments/downsampling/pip-ind/run.py
@@ -1,4 +1,5 @@
-import argparse
+import configargparse
+import json
 import logging
 import numpy as np
 import pickle
@@ -17,12 +18,11 @@ torch.manual_seed(123)
 
 
 batch_size = 8
-feature_fname = 'mfcc_delta_features.pt'
 
 logging.basicConfig(level=logging.INFO)
 
 # Parse command line parameters
-parser = argparse.ArgumentParser()
+parser = configargparse.get_argument_parser('platalea')
 parser.add_argument(
     '--asr_model_dir',
     help='Path to the directory where the pretrained ASR model is stored',
@@ -32,7 +32,7 @@ parser.add_argument(
     help='Path to the directory where the pretrained text-image model is \
     stored',
     dest='text_image_model_dir', type=str, action='store')
-args = parser.parse_args()
+args, unknown_args = parser.parse_known_args()
 
 factors = [3, 9, 27, 81, 243]
 lz = len(str(abs(factors[-1])))
@@ -40,10 +40,9 @@ for ds_factor in factors:
     logging.info('Loading data')
     data = dict(
         train=D.flickr8k_loader(split='train', batch_size=batch_size,
-                                shuffle=True, feature_fname=feature_fname,
-                                downsampling_factor=ds_factor),
+                                shuffle=True, downsampling_factor=ds_factor),
         val=D.flickr8k_loader(split='val', batch_size=batch_size,
-                              shuffle=False, feature_fname=feature_fname))
+                              shuffle=False))
     fd = D.Flickr8KData
     if args.asr_model_dir:
         config_fpath = os.path.join(args.asr_model_dir, 'config.pkl')
@@ -52,9 +51,7 @@ for ds_factor in factors:
     else:
         fd.init_vocabulary(data['train'].dataset)
         # Saving config
-        pickle.dump(dict(feature_fname=feature_fname,
-                         label_encoder=fd.get_label_encoder(),
-                         language='en'),
+        pickle.dump(data['train'].dataset.get_config(),
                     open('config.pkl', 'wb'))
 
     if args.asr_model_dir:
@@ -83,9 +80,7 @@ for ds_factor in factors:
         fd.le = config['label_encoder']
     elif args.asr_model_dir:
         # Saving config for text-image model
-        pickle.dump(dict(feature_fname=feature_fname,
-                         label_encoder=fd.get_label_encoder(),
-                         language='en'),
+        pickle.dump(data['train'].dataset.get_config(),
                     open('config.pkl', 'wb'))
 
     if args.text_image_model_dir:
@@ -110,7 +105,8 @@ for ds_factor in factors:
     image_e = net.embed_image(data['image'])
     text_e = net.embed_text(hyp_asr)
     result = E.ranking(image_e, text_e, correct)
-    print(dict(medr=np.median(result['ranks']),
-               recall={1: np.mean(result['recall'][1]),
-                       5: np.mean(result['recall'][5]),
-                       10: np.mean(result['recall'][10])}))
+    res_out = dict(medr=np.median(result['ranks']),
+                   recall={1: np.mean(result['recall'][1]),
+                           5: np.mean(result['recall'][5]),
+                           10: np.mean(result['recall'][10])})
+    json.dump(res_out, open('result.json', 'w'))

--- a/experiments/downsampling/text-image/run.py
+++ b/experiments/downsampling/text-image/run.py
@@ -13,7 +13,6 @@ torch.manual_seed(123)
 batch_size = 32
 hidden_size = 1024
 dropout = 0.0
-feature_fname = 'mfcc_delta_features.pt'
 
 logging.basicConfig(level=logging.INFO)
 
@@ -23,17 +22,14 @@ for ds_factor in factors:
     logging.info('Loading data')
     data = dict(
         train=D.flickr8k_loader(split='train', batch_size=batch_size,
-                                shuffle=True, feature_fname=feature_fname,
-                                downsampling_factor=ds_factor),
+                                shuffle=True, downsampling_factor=ds_factor),
         val=D.flickr8k_loader(split='val', batch_size=batch_size,
-                              shuffle=False, feature_fname=feature_fname))
+                              shuffle=False))
     fd = D.Flickr8KData
     fd.init_vocabulary(data['train'].dataset)
 
     # Saving config
-    pickle.dump(dict(feature_fname=feature_fname,
-                     label_encoder=fd.get_label_encoder(),
-                     language='en'),
+    pickle.dump(data['train'].dataset.get_config(),
                 open('config.pkl', 'wb'))
 
     logging.info('Building model')

--- a/experiments/jp/mtl-slt/run.py
+++ b/experiments/jp/mtl-slt/run.py
@@ -13,7 +13,6 @@ torch.manual_seed(123)
 batch_size = 8
 hidden_size = 1024
 dropout = 0.0
-feature_fname = 'mfcc_delta_features.pt'
 language = 'jp'
 
 logging.basicConfig(level=logging.INFO)
@@ -21,16 +20,14 @@ logging.basicConfig(level=logging.INFO)
 logging.info('Loading data')
 data = dict(
     train=D.flickr8k_loader(split='train', batch_size=batch_size, shuffle=True,
-                            feature_fname=feature_fname, language=language),
+                            language=language),
     val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False,
-                          feature_fname=feature_fname, language=language))
+                          language=language))
 fd = D.Flickr8KData
 fd.init_vocabulary(data['train'].dataset)
 
 # Saving config
-pickle.dump(dict(feature_fname=feature_fname,
-                 label_encoder=fd.get_label_encoder(),
-                 language=language),
+pickle.dump(data['train'].dataset.get_config(),
             open('config.pkl', 'wb'))
 
 for n in [(5, 1, 1), (4, 2, 2)]:

--- a/experiments/jp/pip-ind/run.py
+++ b/experiments/jp/pip-ind/run.py
@@ -1,4 +1,5 @@
-import argparse
+import configargparse
+import json
 import logging
 import numpy as np
 import pickle
@@ -17,12 +18,11 @@ torch.manual_seed(123)
 
 
 batch_size = 8
-feature_fname = 'mfcc_delta_features.pt'
 
 logging.basicConfig(level=logging.INFO)
 
 # Parse command line parameters
-parser = argparse.ArgumentParser()
+parser = configargparse.get_argument_parser('platalea')
 parser.add_argument(
     '--asr_model_dir',
     help='Path to the directory where the pretrained ASR model is stored',
@@ -32,14 +32,14 @@ parser.add_argument(
     help='Path to the directory where the pretrained text-image model is \
     stored',
     dest='text_image_model_dir', type=str, action='store')
-args = parser.parse_args()
+args, unknown_args = parser.parse_known_args()
 
 logging.info('Loading data')
 data = dict(
     train=D.flickr8k_loader(split='train', batch_size=batch_size, shuffle=True,
-                            feature_fname=feature_fname, language='jp'),
+                            language='jp'),
     val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False,
-                          feature_fname=feature_fname, language='jp'))
+                          language='jp'))
 fd = D.Flickr8KData
 if args.asr_model_dir:
     config_fpath = os.path.join(args.asr_model_dir, 'config.pkl')
@@ -48,9 +48,7 @@ if args.asr_model_dir:
 else:
     fd.init_vocabulary(data['train'].dataset)
     # Saving config
-    pickle.dump(dict(feature_fname=feature_fname,
-                     label_encoder=fd.get_label_encoder(),
-                     language='jp'),
+    pickle.dump(data['train'].dataset.get_config(),
                 open('config.pkl', 'wb'))
 
 if args.asr_model_dir:
@@ -75,9 +73,7 @@ if args.text_image_model_dir:
     fd.le = config['label_encoder']
 elif args.asr_model_dir:
     # Saving config for text-image model
-    pickle.dump(dict(feature_fname=feature_fname,
-                     label_encoder=fd.get_label_encoder(),
-                     language='en'),
+    pickle.dump(data['train'].dataset.get_config(),
                 open('config.pkl', 'wb'))
 
 if args.text_image_model_dir:
@@ -98,7 +94,8 @@ correct = data['correct'].cpu().numpy()
 image_e = net.embed_image(data['image'])
 text_e = net.embed_text(hyp_asr)
 result = E.ranking(image_e, text_e, correct)
-print(dict(medr=np.median(result['ranks']),
-           recall={1: np.mean(result['recall'][1]),
-                   5: np.mean(result['recall'][5]),
-                   10: np.mean(result['recall'][10])}))
+res_out = dict(medr=np.median(result['ranks']),
+               recall={1: np.mean(result['recall'][1]),
+                       5: np.mean(result['recall'][5]),
+                       10: np.mean(result['recall'][10])})
+json.dump(res_out, open('result.json', 'w'))

--- a/experiments/jp/pip-seq/run.py
+++ b/experiments/jp/pip-seq/run.py
@@ -1,4 +1,4 @@
-import argparse
+import configargparse
 import logging
 import pickle
 import os
@@ -15,24 +15,23 @@ torch.manual_seed(123)
 
 
 batch_size = 8
-feature_fname = 'mfcc_delta_features.pt'
 
 logging.basicConfig(level=logging.INFO)
 
 # Parse command line parameters
-parser = argparse.ArgumentParser()
+parser = configargparse.get_argument_parser('platalea')
 parser.add_argument(
     '--asr_model_dir',
     help='Path to the directory where the pretrained ASR model is stored',
     dest='asr_model_dir', type=str, action='store')
-args = parser.parse_args()
+args, unknown_args = parser.parse_known_args()
 
 logging.info('Loading data')
 data = dict(
     train=D.flickr8k_loader(split='train', batch_size=batch_size, shuffle=True,
-                            feature_fname=feature_fname, language='jp'),
+                            language='jp'),
     val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False,
-                          feature_fname=feature_fname, language='jp'))
+                          language='jp'))
 fd = D.Flickr8KData
 if args.asr_model_dir:
     config_fpath = os.path.join(args.asr_model_dir, 'config.pkl')
@@ -41,9 +40,7 @@ if args.asr_model_dir:
 else:
     fd.init_vocabulary(data['train'].dataset)
     # Saving config
-    pickle.dump(dict(feature_fname=feature_fname,
-                     label_encoder=fd.get_label_encoder(),
-                     language='jp'),
+    pickle.dump(data['train'].dataset.get_config(),
                 open('config.pkl', 'wb'))
 
 if args.asr_model_dir:
@@ -76,9 +73,7 @@ for set_name in ['train', 'val']:
 
 if args.asr_model_dir:
     # Saving config for text-image model
-    pickle.dump(dict(feature_fname=feature_fname,
-                     label_encoder=fd.get_label_encoder(),
-                     language='en'),
+    pickle.dump(data['train'].dataset.get_config(),
                 open('config.pkl', 'wb'))
 
 logging.info('Building model text-image')

--- a/experiments/jp/slt/run.py
+++ b/experiments/jp/slt/run.py
@@ -1,5 +1,4 @@
 import logging
-import numpy as np
 import pickle
 import torch
 import torch.nn as nn
@@ -13,23 +12,20 @@ torch.manual_seed(123)
 batch_size = 8
 hidden_size = 1024
 dropout = 0.0
-feature_fname = 'mfcc_delta_features.pt'
 
 logging.basicConfig(level=logging.INFO)
 
 logging.info('Loading data')
 data = dict(
     train=D.flickr8k_loader(split='train', batch_size=batch_size, shuffle=True,
-                            feature_fname=feature_fname, language='jp'),
+                            language='jp'),
     val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False,
-                          feature_fname=feature_fname, language='jp'))
+                          language='jp'))
 fd = D.Flickr8KData
 fd.init_vocabulary(data['train'].dataset)
 
 # Saving config
-pickle.dump(dict(feature_fname=feature_fname,
-                 label_encoder=fd.get_label_encoder(),
-                 language='jp'),
+pickle.dump(data['train'].dataset.get_config(),
             open('config.pkl', 'wb'))
 
 config = dict(

--- a/experiments/jp/text-image/run.py
+++ b/experiments/jp/text-image/run.py
@@ -11,23 +11,20 @@ torch.manual_seed(123)
 batch_size = 32
 hidden_size = 1024
 dropout = 0.0
-feature_fname = 'mfcc_delta_features.pt'
 
 logging.basicConfig(level=logging.INFO)
 
 logging.info('Loading data')
 data = dict(
     train=D.flickr8k_loader(split='train', batch_size=batch_size, shuffle=True,
-                            feature_fname=feature_fname, language='jp'),
+                            language='jp'),
     val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False,
-                          feature_fname=feature_fname, language='jp'))
+                          language='jp'))
 fd = D.Flickr8KData
 fd.init_vocabulary(data['train'].dataset)
 
 # Saving config
-pickle.dump(dict(feature_fname=feature_fname,
-                 label_encoder=fd.get_label_encoder(),
-                 language='jp'),
+pickle.dump(data['train'].dataset.get_config(),
             open('config.pkl', 'wb'))
 
 logging.info('Building model')

--- a/experiments/mtl-asr/run.py
+++ b/experiments/mtl-asr/run.py
@@ -12,23 +12,18 @@ torch.manual_seed(123)
 batch_size = 8
 hidden_size = 1024
 dropout = 0.0
-feature_fname = 'mfcc_delta_features.pt'
 
 logging.basicConfig(level=logging.INFO)
 
 logging.info('Loading data')
 data = dict(
-    train=D.flickr8k_loader(split='train', batch_size=batch_size,
-                            shuffle=True, feature_fname=feature_fname),
-    val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False,
-                          feature_fname=feature_fname))
+    train=D.flickr8k_loader(split='train', batch_size=batch_size, shuffle=True),
+    val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False))
 fd = D.Flickr8KData
 fd.init_vocabulary(data['train'].dataset)
 
 # Saving config
-pickle.dump(dict(feature_fname=feature_fname,
-                 label_encoder=fd.get_label_encoder(),
-                 language='en'),
+pickle.dump(data['train'].dataset.get_config(),
             open('config.pkl', 'wb'))
 
 config = dict(

--- a/experiments/mtl-parallel/run.py
+++ b/experiments/mtl-parallel/run.py
@@ -10,16 +10,13 @@ torch.manual_seed(123)
 batch_size = 8
 hidden_size = 1024
 dropout = 0.0
-feature_fname = 'mfcc_delta_features.pt'
 
 logging.basicConfig(level=logging.INFO)
 
 logging.info('Loading data')
 data = dict(
-    train=D.flickr8k_loader(split='train', batch_size=batch_size,
-                            shuffle=True, feature_fname=feature_fname),
-    val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False,
-                          feature_fname=feature_fname))
+    train=D.flickr8k_loader(split='train', batch_size=batch_size, shuffle=True),
+    val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False))
 fd = D.Flickr8KData
 fd.init_vocabulary(data['train'].dataset)
 

--- a/experiments/mtl-st/run.py
+++ b/experiments/mtl-st/run.py
@@ -12,23 +12,18 @@ torch.manual_seed(123)
 batch_size = 8
 hidden_size = 1024
 dropout = 0.0
-feature_fname = 'mfcc_delta_features.pt'
 
 logging.basicConfig(level=logging.INFO)
 
 logging.info('Loading data')
 data = dict(
-    train=D.flickr8k_loader(split='train', batch_size=batch_size,
-                            shuffle=True, feature_fname=feature_fname),
-    val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False,
-                          feature_fname=feature_fname))
+    train=D.flickr8k_loader(split='train', batch_size=batch_size, shuffle=True),
+    val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False))
 fd = D.Flickr8KData
 fd.init_vocabulary(data['train'].dataset)
 
 # Saving config
-pickle.dump(dict(feature_fname=feature_fname,
-                 label_encoder=fd.get_label_encoder(),
-                 language='en'),
+pickle.dump(data['train'].dataset.get_config(),
             open('config.pkl', 'wb'))
 
 config = dict(

--- a/experiments/pip-ind/run.py
+++ b/experiments/pip-ind/run.py
@@ -1,4 +1,5 @@
-import argparse
+import configargparse
+import json
 import logging
 import numpy as np
 import pickle
@@ -17,12 +18,11 @@ torch.manual_seed(123)
 
 
 batch_size = 8
-feature_fname = 'mfcc_delta_features.pt'
 
 logging.basicConfig(level=logging.INFO)
 
 # Parse command line parameters
-parser = argparse.ArgumentParser()
+parser = configargparse.get_argument_parser('platalea')
 parser.add_argument(
     '--asr_model_dir',
     help='Path to the directory where the pretrained ASR model is stored',
@@ -32,14 +32,12 @@ parser.add_argument(
     help='Path to the directory where the pretrained text-image model is \
     stored',
     dest='text_image_model_dir', type=str, action='store')
-args = parser.parse_args()
+args, unknown_args = parser.parse_known_args()
 
 logging.info('Loading data')
 data = dict(
-    train=D.flickr8k_loader(split='train', batch_size=batch_size, shuffle=True,
-                            feature_fname=feature_fname),
-    val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False,
-                          feature_fname=feature_fname))
+    train=D.flickr8k_loader(split='train', batch_size=batch_size, shuffle=True),
+    val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False))
 fd = D.Flickr8KData
 if args.asr_model_dir:
     config_fpath = os.path.join(args.asr_model_dir, 'config.pkl')
@@ -48,9 +46,7 @@ if args.asr_model_dir:
 else:
     fd.init_vocabulary(data['train'].dataset)
     # Saving config
-    pickle.dump(dict(feature_fname=feature_fname,
-                     label_encoder=fd.get_label_encoder(),
-                     language='en'),
+    pickle.dump(data['train'].dataset.get_config(),
                 open('config.pkl', 'wb'))
 
 if args.asr_model_dir:
@@ -75,9 +71,7 @@ if args.text_image_model_dir:
     fd.le = config['label_encoder']
 elif args.asr_model_dir:
     # Saving config for text-image model
-    pickle.dump(dict(feature_fname=feature_fname,
-                     label_encoder=fd.get_label_encoder(),
-                     language='en'),
+    pickle.dump(data['train'].get_config(),
                 open('config.pkl', 'wb'))
 
 if args.text_image_model_dir:
@@ -98,7 +92,8 @@ correct = data['correct'].cpu().numpy()
 image_e = net.embed_image(data['image'])
 text_e = net.embed_text(hyp_asr)
 result = E.ranking(image_e, text_e, correct)
-print(dict(medr=np.median(result['ranks']),
-           recall={1: np.mean(result['recall'][1]),
-                   5: np.mean(result['recall'][5]),
-                   10: np.mean(result['recall'][10])}))
+res_out = dict(medr=np.median(result['ranks']),
+               recall={1: np.mean(result['recall'][1]),
+                       5: np.mean(result['recall'][5]),
+                       10: np.mean(result['recall'][10])})
+json.dump(res_out, open('result.json', 'w'))

--- a/experiments/pip-seq/run.py
+++ b/experiments/pip-seq/run.py
@@ -1,4 +1,4 @@
-import argparse
+import configargparse
 import logging
 import pickle
 import os
@@ -15,24 +15,21 @@ torch.manual_seed(123)
 
 
 batch_size = 8
-feature_fname = 'mfcc_delta_features.pt'
 
 logging.basicConfig(level=logging.INFO)
 
 # Parse command line parameters
-parser = argparse.ArgumentParser()
+parser = configargparse.get_argument_parser('platalea')
 parser.add_argument(
     '--asr_model_dir',
     help='Path to the directory where the pretrained ASR model is stored',
     dest='asr_model_dir', type=str, action='store')
-args = parser.parse_args()
+args, unknown_args = parser.parse_known_args()
 
 logging.info('Loading data')
 data = dict(
-    train=D.flickr8k_loader(split='train', batch_size=batch_size, shuffle=True,
-                            feature_fname=feature_fname),
-    val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False,
-                          feature_fname=feature_fname))
+    train=D.flickr8k_loader(split='train', batch_size=batch_size, shuffle=True),
+    val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False))
 fd = D.Flickr8KData
 if args.asr_model_dir:
     config_fpath = os.path.join(args.asr_model_dir, 'config.pkl')
@@ -41,9 +38,7 @@ if args.asr_model_dir:
 else:
     fd.init_vocabulary(data['train'].dataset)
     # Saving config
-    pickle.dump(dict(feature_fname=feature_fname,
-                     label_encoder=fd.get_label_encoder(),
-                     language='en'),
+    pickle.dump(data['train'].dataset.get_config(),
                 open('config.pkl', 'wb'))
 
 if args.asr_model_dir:
@@ -76,9 +71,7 @@ for set_name in ['train', 'val']:
 
 if args.asr_model_dir:
     # Saving config for text-image model
-    pickle.dump(dict(feature_fname=feature_fname,
-                     label_encoder=fd.get_label_encoder(),
-                     language='en'),
+    pickle.dump(data['train'].get_config(),
                 open('config.pkl', 'wb'))
 
 logging.info('Building model text-image')

--- a/experiments/text-image/run.py
+++ b/experiments/text-image/run.py
@@ -11,23 +11,18 @@ torch.manual_seed(123)
 batch_size = 32
 hidden_size = 1024
 dropout = 0.0
-feature_fname = 'mfcc_delta_features.pt'
 
 logging.basicConfig(level=logging.INFO)
 
 logging.info('Loading data')
 data = dict(
-    train=D.flickr8k_loader(split='train', batch_size=batch_size, shuffle=True,
-                            feature_fname=feature_fname),
-    val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False,
-                          feature_fname=feature_fname))
+    train=D.flickr8k_loader(split='train', batch_size=batch_size, shuffle=True),
+    val=D.flickr8k_loader(split='val', batch_size=batch_size, shuffle=False))
 fd = D.Flickr8KData
 fd.init_vocabulary(data['train'].dataset)
 
 # Saving config
-pickle.dump(dict(feature_fname=feature_fname,
-                 label_encoder=fd.get_label_encoder(),
-                 language='en'),
+pickle.dump(data['train'].dataset.get_config(),
             open('config.pkl', 'wb'))
 
 logging.info('Building model')

--- a/platalea/__init__.py
+++ b/platalea/__init__.py
@@ -2,6 +2,7 @@ import configargparse
 
 configargparse.init_argument_parser(name='platalea', default_config_files=['config.ini', 'config.yml'])
 parser = configargparse.get_argument_parser(name='platalea')
+parser.add_argument('-c', '--config', is_config_file=True, help='config file path')
 parser.add_argument('--data_root', env_var='PLATALEA_DATA_ROOT',
                     action='store', default='/roaming/gchrupal/datasets/flickr8k/',
                     dest='data_root',

--- a/platalea/dataset.py
+++ b/platalea/dataset.py
@@ -45,14 +45,16 @@ class Flickr8KData(torch.utils.data.Dataset):
 
     def __init__(self, root, feature_fname, split='train', language='en',
                  downsampling_factor=None):
+        self.root = root
+        self.split = split
+        self.feature_fname = feature_fname
+        self.language = language
         if language == 'en':
             self.text_key = 'raw'
         elif language == 'jp':
             self.text_key = 'raw_jp'
         else:
             raise ValueError('Language {} not supported.'.format(language))
-        self.root = root
-        self.split = split
         root_path = pathlib.Path(root)
         with open(root_path / platalea.config.args.meta) as fmeta:
             self.metadata = json.load(fmeta)['images']
@@ -97,6 +99,11 @@ class Flickr8KData(torch.utils.data.Dataset):
 
     def __len__(self):
         return len(self.split_data)
+
+    def get_config(self):
+        return dict(feature_fname=self.feature_fname,
+                    label_encoder=self.get_label_encoder(),
+                    language=self.language)
 
     def evaluation(self):
         """Returns image features, caption features, and a boolean array
@@ -157,7 +164,8 @@ def collate_fn(data, max_frames=2048):
 
 
 def flickr8k_loader(split='train', batch_size=32, shuffle=False,
-                    max_frames=2048, feature_fname=platalea.config.args.audio_features_fn,
+                    max_frames=2048,
+                    feature_fname=platalea.config.args.audio_features_fn,
                     language='en', downsampling_factor=None):
     return torch.utils.data.DataLoader(
         dataset=Flickr8KData(root=platalea.config.args.data_root,

--- a/utils/copy_best.py
+++ b/utils/copy_best.py
@@ -8,7 +8,7 @@ network to net.best.pt.
 """
 
 
-import argparse
+import configargparse
 import numpy as np
 from shutil import copyfile
 
@@ -29,9 +29,9 @@ def copy_best(result_fpath='result.json', save_fpath='net.best.pt',
 if __name__ == '__main__':
     # Parsing command line
     doc = __doc__.strip("\n").split("\n", 1)
-    parser = argparse.ArgumentParser(
-        description=doc[0], epilog=doc[1],
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = configargparse.get_argument_parser('platalea')
+    parser.description = doc[0]
+    parser.epilog = doc[1]
     parser.add_argument(
         '--result', help='Path to the JSON file containing the results.',
         type=str, action='store', default='result.json')
@@ -43,6 +43,6 @@ if __name__ == '__main__':
         help='Type of experiment. Determines which metric is used.',
         type=str, action='store', choices=['retrieval', 'asr', 'mtl', 'slt'],
         default='retrieval')
-    args = parser.parse_args()
+    args, unknown_args = parser.parse_known_args()
 
     copy_best(args.result, args.save, args.experiment_type)

--- a/utils/evaluate_asr.py
+++ b/utils/evaluate_asr.py
@@ -1,4 +1,4 @@
-import argparse
+import configargparse
 import json
 import logging
 import pickle
@@ -14,11 +14,11 @@ batch_size = 16
 logging.basicConfig(level=logging.INFO)
 
 # Parse command line parameters
-parser = argparse.ArgumentParser()
+parser = configargparse.get_argument_parser('platalea')
 parser.add_argument('path', metavar='path', help='Model\'s path')
 parser.add_argument('-b', help='Use beam decoding', dest='use_beam_decoding',
                     action='store_true', default=False)
-args = parser.parse_args()
+args, unknown_args = parser.parse_known_args()
 
 # Loading config
 conf = pickle.load(open('config.pkl', 'rb'))

--- a/utils/get_best_score.py
+++ b/utils/get_best_score.py
@@ -8,7 +8,7 @@ corresponding score.
 """
 
 
-import argparse
+import configargparse
 import json
 import numpy as np
 
@@ -45,9 +45,9 @@ def get_best_score(result_fpath='result.json', experiment_type='retrieval'):
 if __name__ == '__main__':
     # Parsing command line
     doc = __doc__.strip("\n").split("\n", 1)
-    parser = argparse.ArgumentParser(
-        description=doc[0], epilog=doc[1],
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = configargparse.get_argument_parser('platalea')
+    parser.description = doc[0]
+    parser.epilog = doc[1]
     parser.add_argument(
         'res_fpath', help='Path to the JSON file(s) containing the results.',
         type=str, action='store', default='result.json', nargs='+')
@@ -60,7 +60,7 @@ if __name__ == '__main__':
         help='Type of experiment. Determines which metric is used.',
         type=str, action='store', choices=['retrieval', 'asr', 'mtl', 'slt'],
         default='retrieval')
-    args = parser.parse_args()
+    args, unknown_args = parser.parse_known_args()
 
     scores = [str(get_best_score(f, args.experiment_type)) for f in args.res_fpath]
     print(args.separator.join(scores))


### PR DESCRIPTION
- use configargparse everywhere
- remove feature_fname in experiment scripts when redundant with default
config
- added get_config() to Flickr8KData to simplify saving the dataset
config
- added `-c config_fname` option to the parser so that a config file can
be added from command line (e.g. to test wit flickr1d)

+ small fix: saving final results in json format in pip-in/run.py