### PR TITLE
fix bug in logging: change step_loss to loss_value

### DIFF
--- a/platalea/basic.py
+++ b/platalea/basic.py
@@ -116,7 +116,7 @@ def experiment(net, data, config):
                     logging.info("train %d %d %f", epoch, j, cost['cost'] / cost['N'])
                 else:
                     if debug_logging_active:
-                        logging.debug("train %d %d %f %f", epoch, j, cost['cost'] / cost['N'], step_loss)
+                        logging.debug("train %d %d %f %f", epoch, j, cost['cost'] / cost['N'], loss_value)
                 if not config.get('validate_on_cpu'):
                     if j % 400 == 0:
                         validation_loss = val_loss(net)


### PR DESCRIPTION
Fix bug in logging. We were trying to log the step_loss but the variable was called loss_value instead. 