### PR TITLE
turn off wandb before running experiments on ci

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -39,7 +39,8 @@ jobs:
     - run: conda --version
     - run: which python
     - run: conda install pytorch -c pytorch
-    - run: pip install torchvision
+    - run: pip install torchvision wandb
+    - run: wandb off
     - name: install dependencies for tests
       run: pip install sklearn python-Levenshtein coverage
 

--- a/platalea/basic.py
+++ b/platalea/basic.py
@@ -63,7 +63,15 @@ class SpeechImage(nn.Module):
 def dict_values_to_device(data, device):
     return {key: value.to(device) for key, value in data.items()}
 
-def experiment(net, data, config):
+
+def experiment(net, data, config,
+               wandb_log=None,
+               wandb_project="platalea",
+               wandb_entity="spokenlanguage"):
+    """
+
+    :type wandb_log: (nested) dict with complete config to be logged by wandb
+    """
     def val_loss(net):
         _device = platalea.hardware.device()
         net.eval()  # switch to eval mode
@@ -73,6 +81,11 @@ def experiment(net, data, config):
             result.append(net.cost(item).item())
         net.train()  # back to train mode
         return torch.tensor(result).mean()
+
+    if not wandb_log:
+        wandb_log = config
+    wandb.init(project=wandb_project, entity=wandb_entity, config=wandb_log)
+    wandb.watch(net)
 
     _device = platalea.hardware.device()
     net.to(_device)

--- a/platalea/basic.py
+++ b/platalea/basic.py
@@ -129,7 +129,7 @@ def experiment(net, data, config,
                     logging.info("train %d %d %f", epoch, j, cost['cost'] / cost['N'])
                 else:
                     if debug_logging_active:
-                        logging.debug("train %d %d %f %f", epoch, j, cost['cost'] / cost['N'], step_loss)
+                        logging.debug("train %d %d %f %f", epoch, j, cost['cost'] / cost['N'], loss_value)
                 if not config.get('validate_on_cpu'):
                     if j % 400 == 0:
                         validation_loss = val_loss(net)

--- a/platalea/experiments/flickr8k/transformer.py
+++ b/platalea/experiments/flickr8k/transformer.py
@@ -1,7 +1,6 @@
 import logging
 import random
 import torch
-import wandb  # cloud logging
 
 import platalea.basic as M
 import platalea.encoders
@@ -83,10 +82,6 @@ run_config = dict(max_lr=args.cyclic_lr_max, min_lr=args.cyclic_lr_min, epochs=a
 
 logged_config = dict(run_config=run_config, encoder_config=config, speech_config=speech_config)
 logged_config['encoder_config'].pop('SpeechEncoder')  # Object info is redundant in log.
-print(logged_config)
-
-wandb.init(project="platalea_transformer", entity="spokenlanguage", config=logged_config)
-wandb.watch(net)
 
 logging.info('Training')
-M.experiment(net, data, run_config)
+M.experiment(net, data, run_config, wandb_project='platalea_transformer', wandb_log=logged_config)


### PR DESCRIPTION
turn off wandb when running tests as part of continuous integration.