### PR TITLE
Skip beam search for CI testing

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -102,7 +102,7 @@ jobs:
       env:
         FLICKR8K_ROOT: ${{ github.workspace }}/data/flickr1d
         PLATALEA_EPOCHS: 1
-      run: coverage run --append -m platalea.experiments.flickr8k.pip_seq -c $FLICKR8K_ROOT/config.yml --asr_model_dir=${{ github.workspace }}/asr_out --hidden_size_factor=4
+      run: coverage run --append -m platalea.experiments.flickr8k.pip_seq -c $FLICKR8K_ROOT/config.yml --asr_model_dir=${{ github.workspace }}/asr_out --hidden_size_factor=4 --pip_seq_no_beam_decoding
 
     - name: Collect coverage information
       run: coverage xml

--- a/platalea/experiments/flickr8k/pip_seq.py
+++ b/platalea/experiments/flickr8k/pip_seq.py
@@ -64,7 +64,7 @@ for set_name in ['train', 'val']:
     ds = data[set_name].dataset
     # cProfile.run("extract_trn(net, ds, use_beam_decoding=False)")
     # raise SystemExit
-    hyp_asr, ref_asr = extract_trn(net, ds, use_beam_decoding=True)
+    hyp_asr, ref_asr = extract_trn(net, ds, use_beam_decoding=False)
     # Replacing original transcriptions with ASR/SLT's output
     for i in range(len(hyp_asr)):
         item = ds.split_data[i]

--- a/platalea/experiments/flickr8k/pip_seq.py
+++ b/platalea/experiments/flickr8k/pip_seq.py
@@ -18,6 +18,9 @@ args.add_argument(
     '--asr_model_dir',
     help='Path to the directory where the pretrained ASR/SLT model is stored',
     dest='asr_model_dir', type=str, action='store')
+
+args.add_argument('--pip_seq_use_beam_decoding', default=True, action='store_true')
+args.add_argument('--pip_seq_no_beam_decoding', dest='pip_seq_use_beam_decoding', action='store_false')
 args.enable_help()
 args.parse()
 
@@ -64,7 +67,7 @@ for set_name in ['train', 'val']:
     ds = data[set_name].dataset
     # cProfile.run("extract_trn(net, ds, use_beam_decoding=False)")
     # raise SystemExit
-    hyp_asr, ref_asr = extract_trn(net, ds, use_beam_decoding=False)
+    hyp_asr, ref_asr = extract_trn(net, ds, use_beam_decoding=args.pip_seq_use_beam_decoding)
     # Replacing original transcriptions with ASR/SLT's output
     for i in range(len(hyp_asr)):
         item = ds.split_data[i]


### PR DESCRIPTION
As explained in #18, this added option to not use beam search in the `pip_seq` experiment reduces CI test time and increases code coverage. It changes nothing of the previous behavior if the options are not used.