### PR TITLE
Fix input to linear layer in SpeechEncoderTransformer

### DIFF
--- a/platalea/encoders.py
+++ b/platalea/encoders.py
@@ -189,11 +189,15 @@ class SpeechEncoderTransformer(nn.Module):
         # update the lengths to compensate for the convolution subsampling
         lengths = inout(self.Conv, lengths)
 
-        # source sequence dimension must be first (but is last in input),
-        # batch dimension in the middle (was first in input), feature dimension last
-        x = x.permute(2, 0, 1)
+        # # source sequence dimension must be first (but is last in input),
+        # # batch dimension in the middle (was first in input), feature dimension last
+        # x = x.permute(2, 0, 1)
+        x = x.permute(0, 2, 1)
 
         x = self.scale_conv_to_trafo(x)
+
+        x = x.permute(1, 0, 2)
+
         mask = generate_padding_mask(x.size()[1], lengths).to(platalea.hardware.device())
         x = torch.utils.checkpoint.checkpoint(lambda a, b: self.Transformer(a, src_key_padding_mask=b),
                                               x, mask)

--- a/platalea/encoders.py
+++ b/platalea/encoders.py
@@ -159,22 +159,8 @@ class SpeechEncoderTransformer(nn.Module):
     def __init__(self, config):
         super(SpeechEncoderTransformer, self).__init__()
 
-        conv = config['conv2d']
-        in_channels = conv.pop('in_channels')
-        conv['in_channels'] = 1
-        self.Conv1 = nn.Conv2d(**conv)
-
-        self.ReLU1 = nn.ReLU()
-
-        conv['in_channels'] = conv['out_channels']
-        self.Conv2 = nn.Conv2d(**conv)
-
-        self.ReLU2 = nn.ReLU()
-
-        # determine size of the scaling layer between convolutional layers and transformer stack
-        after_first_conv = inout(self.Conv1, torch.tensor([in_channels]))[0]
-        after_second_conv = inout(self.Conv2, torch.tensor([after_first_conv]))[0]
-        self.conv_out_dim = after_second_conv * conv['out_channels']
+        conv = config['conv']
+        self.Conv = nn.Conv1d(**conv)
 
         trafo = config['trafo']
         num_layers = trafo.pop('num_encoder_layers', 6)
@@ -185,8 +171,11 @@ class SpeechEncoderTransformer(nn.Module):
         self.Transformer = trafo_layer_type(**trafo)
 
         upsample = config['upsample']
-        self.scale_conv_to_trafo = nn.Linear(in_features=self.conv_out_dim,
-                                             out_features=trafo['d_model'], **upsample)
+        if trafo['d_model'] == conv['out_channels']:
+            self.scale_conv_to_trafo = nn.Identity()
+        else:
+            self.scale_conv_to_trafo = nn.Linear(in_features=conv['out_channels'],
+                                                 out_features=trafo['d_model'], **upsample)
 
         att = config.get('att', None)
         if att is not None:
@@ -195,20 +184,15 @@ class SpeechEncoderTransformer(nn.Module):
             self.att = None
 
     def forward(self, src, lengths):
-        x = self.Conv1(src[:, None])
-        x = self.ReLU1(x)
-        x = self.Conv2(x)
-        x = self.ReLU2(x)
+        x = self.Conv(src)
 
         # update the lengths to compensate for the convolution subsampling
-        lengths = inout(self.Conv1, lengths)
-        lengths = inout(self.Conv2, lengths)
+        lengths = inout(self.Conv, lengths)
 
         # # source sequence dimension must be first (but is last in input),
         # # batch dimension in the middle (was first in input), feature dimension last
         # x = x.permute(2, 0, 1)
-        x_size = x.size()
-        x = x.permute(0, 3, 1, 2).reshape((x_size[0], x_size[3], self.conv_out_dim))
+        x = x.permute(0, 2, 1)
 
         x = self.scale_conv_to_trafo(x)
 

--- a/platalea/experiments/flickr8k/transformer.py
+++ b/platalea/experiments/flickr8k/transformer.py
@@ -60,6 +60,7 @@ data = dict(
 
 
 speech_config = {'conv': dict(in_channels=39, out_channels=64, kernel_size=6, stride=2, padding=0, bias=False),
+                 'conv2d': dict(in_channels=39, out_channels=256, kernel_size=(3, 3), stride=(2, 2), bias=False),
                  'trafo': dict(d_model=args.trafo_d_model, dim_feedforward=args.trafo_feedforward_dim,
                                num_encoder_layers=args.trafo_encoder_layers, dropout=args.trafo_dropout, nhead=args.trafo_heads),
                  'upsample': dict(bias=True),

--- a/platalea/experiments/flickr8k/transformer.py
+++ b/platalea/experiments/flickr8k/transformer.py
@@ -60,7 +60,6 @@ data = dict(
 
 
 speech_config = {'conv': dict(in_channels=39, out_channels=64, kernel_size=6, stride=2, padding=0, bias=False),
-                 'conv2d': dict(in_channels=39, out_channels=256, kernel_size=(3, 3), stride=(2, 2), bias=False),
                  'trafo': dict(d_model=args.trafo_d_model, dim_feedforward=args.trafo_feedforward_dim,
                                num_encoder_layers=args.trafo_encoder_layers, dropout=args.trafo_dropout, nhead=args.trafo_heads),
                  'upsample': dict(bias=True),


### PR DESCRIPTION
The order of the dimensions in the input layer was wrong. This shouldn't matter that much, but at least it is more correct. One experiment, [reported on wandb here](https://wandb.ai/spokenlanguage/platalea_transformer/reports/Permute-for-linear-layer--Vmlldzo0MzUxMDE), showed no adverse effects, and in fact a small improvement in performance, though we cannot be sure just from this one experiment that this is not just a random effect.

Note that this PR also contains a commit (and a revert of that commit) in which we tried replacing the 1D conv layer with 2D convolutional layers. This worsened performance significantly, as [reported on wandb here](https://wandb.ai/spokenlanguage/platalea_transformer/reports/2D-convolutional-starting-layers--Vmlldzo0MzU0Njc), so we will leave this out, but merge it anyway so that it is in history and could perhaps be revisited some day when necessary.